### PR TITLE
change checksum to sha256

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # TODO figure out how to get permalinks from sourceforge
 default['yajsw']['url'] = 'http://softlayer-dal.dl.sourceforge.net/project/yajsw/yajsw/yajsw-stable-11.11/yajsw-stable-11.11.zip'
 default['yajsw']['file'] = 'yajsw-stable-11.11.zip'
-default['yajsw']['checksum'] = '3b4fff8475e48cb001c38a42c27c953b'
+default['yajsw']['checksum'] = 'aeb845a7d77184b8a1cbd68ae26c7f07a74952f6e79fb31d3f8f41ba52c4c872'
 default['yajsw']['dirname'] = 'yajsw-stable-11.11'
 
 # yajsw install location


### PR DESCRIPTION
Chef 12 validates a downloaded file's checksum using SHA-256 by default.  This swaps from md5 to sha256
