### PR TITLE
Add matcher and test for LWRP

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,9 @@
+if defined?(ChefSpec)
+  def create_yajsw_app(app)
+    ChefSpec::Matchers::ResourceMatcher.new(:yajsw_app, :create, app)
+  end
+
+  def update_yajsw_app(app)
+    ChefSpec::Matchers::ResourceMatcher.new(:yajsw_app, :update, app)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license          'Apache 2.0'
 description      'Installs/Configures yajsw'
 long_description 'Installs/Configures yajsw'
-version          '0.2.3'
+version          '0.2.4'
 
 depends 'maven'
 depends 'git'

--- a/spec/unit/recipes/config_app_spec.rb
+++ b/spec/unit/recipes/config_app_spec.rb
@@ -13,7 +13,7 @@ describe 'yajsw::config_app' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::Runner.new(step_into: ['yajsw_app'], log_level: :warn, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end
@@ -39,6 +39,14 @@ describe 'yajsw::config_app' do
 
         it "should render the yajsw wrapper config for the default app" do
           expect(chef_run).to render_file('/usr/local/yajsw_apps/myapp/conf/wrapper.conf').with_content(/wrapper\.java\.app\.jar=lib\/com\.company\.myapp\.jar$/)
+        end
+
+        it "should create yajsw app myapp" do
+          expect(chef_run).to create_yajsw_app("myapp")
+        end
+
+        it "should update yajsw app myapp" do
+          expect(chef_run).to update_yajsw_app("myapp")
         end
       end
     end


### PR DESCRIPTION
This adds two custom matches to allow one to test their cookbook which includes this one in the form:

```ruby
it "should create yajsw app myapp" do
  expect(chef_run).to create_yajsw_app("myapp")
end
```

It also has our unit test `step_into` the LWRP and run tests against what happens when it converges.
