### PR TITLE
Remove deprecated platforms and calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 group :unit do
   gem 'berkshelf'
-  gem 'chefspec', '~> 3.1'
+  gem 'chefspec'
 end
 
 group :integration do
@@ -16,5 +16,5 @@ group :integration do
   gem 'kitchen-docker'
   gem 'kitchen-vagrant'
   gem 'serverspec'
-  gem 'busser-serverspec', '~> 0.2.6'
+  gem 'busser-serverspec'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license          'Apache 2.0'
 description      'Installs/Configures yajsw'
 long_description 'Installs/Configures yajsw'
-version          '0.2.4'
+version          '0.2.5'
 
 depends 'maven'
 depends 'git'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'chefspec/server'
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/config_app_spec.rb
+++ b/spec/unit/recipes/config_app_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe 'yajsw::config_app' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -13,7 +13,7 @@ describe 'yajsw::config_app' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(step_into: ['yajsw_app'], log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(step_into: ['yajsw_app'], log_level: :error, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'yajsw::default' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -12,7 +12,7 @@ describe 'yajsw::default' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
           end.converge(described_recipe)
         end
 

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe 'yajsw::package' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -13,7 +13,7 @@ describe 'yajsw::package' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end


### PR DESCRIPTION
* Remove Ubuntu 12.0.4
* Bump to CentOS 6.6
* Replace deprecated calls to ChefSpec::Runner with  ChefSpec::SoloRunner
