### PR TITLE
Update libarchive dependency

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,9 +12,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  - name: ubuntu-15.10
+  - name: ubuntu-16.04
   - name: centos-6.8
-  - name: centos-7.2
+  - name: centos-7.3
 
 suites:
   - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,6 @@
 
 # 0.4.0
 - Migrate to chef custom resources
+
+# 0.5.0
+- Bump libarchive to version 0.7

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ default['yajsw']['install_java'] = true
 default['yajsw']['marker'] = 'stable'
 default['yajsw']['version'] = '11.11'
 default['yajsw']['checksum'] = 'aeb845a7d77184b8a1cbd68ae26c7f07a74952f6e79fb31d3f8f41ba52c4c872'
-default['yajsw']['url'] = "http://heanet.dl.sourceforge.net/project/yajsw/yajsw/yajsw-#{node['yajsw']['marker']}-#{node['yajsw']['version']}/yajsw-#{node['yajsw']['marker']}-#{node['yajsw']['version']}.zip"
+default['yajsw']['url'] = "https://pilotfiber.dl.sourceforge.net/project/yajsw/yajsw/yajsw-#{node['yajsw']['marker']}-#{node['yajsw']['version']}/yajsw-#{node['yajsw']['marker']}-#{node['yajsw']['version']}.zip"
 default['yajsw']['dirname'] = 'yajsw-stable-11.11'
 
 # yajsw install location

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'camden@northpage.com'
 license 'Apache 2.0'
 description 'Installs/Configures yajsw'
 long_description 'Installs/Configures yajsw'
-version '0.4.0'
+version '0.5.0'
 source_url 'https://github.com/NorthPage/yajsw-cookbook'
 issues_url 'https://github.com/NorthPage/yajsw-cookbook/issues' if respond_to?(:issues_url)
 
 depends 'maven'
 depends 'git'
-depends 'libarchive', '~> 0.6.0'
+depends 'libarchive', '~> 0.7'
 depends 'java', '~> 1.0'


### PR DESCRIPTION
This is a tertiary dependency for the solr upgrade.

solr upgrade requires libarchive >= 0.7, np-platform requires solr and yajsw, yajsw requires some version of libarchive . 🤕 